### PR TITLE
data persistence: use volumes instead of bind mounts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,6 +74,6 @@ RUN echo Initialising Zou... && \
     /opt/zou/init_zou.sh
 
 EXPOSE 80
-
+VOLUME ["/var/lib/postgresql", "/opt/zou/zou/thumbnails"]
 ENTRYPOINT ["/tini", "--"]
 CMD ["/opt/zou/start_zou.sh"]

--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ See [Gazu](https://gazu.cg-wire.com/) for details regarding the Python API towar
 
 ```bash
 $ docker build -t cgwire .
-$ docker run -ti --rm -p 80:80 cgwire
+$ docker run -ti --rm -p 80:80 --name cgwire cgwire
 ```
 
-In order to enable data persistence, use these bind mounts for database and thumbnails:
+In order to enable data persistence, use a named volume for database and thumbnails:
 
 ```bash
 $ docker build -t cgwire .
-$ docker run -ti --rm -p 80:80 -v /path/to/local/db:/var/lib/postgresql -v /path/to/local/thumbnails:/opt/zou/zou/thumbnails cgwire
+$ docker run -ti --rm -p 80:80 --name cgwire -v zou-storage:/var/lib/postgresql -v zou-storage:/opt/zou/zou/thumbnails cgwire
 ```
 
 Credentials:

--- a/init_zou.sh
+++ b/init_zou.sh
@@ -11,5 +11,3 @@ zou create_admin admin@example.com
 
 service postgresql stop
 service redis-server stop
-
-tar cvjf postgresql.tar.bz2 /var/lib/postgresql

--- a/start_zou.sh
+++ b/start_zou.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-[ "$(ls -A /var/lib/postgresql)" ] && echo "Running with existing database in /var/lib/postgresql" || ( echo 'Populate initial db'; cd /; tar xvjf /opt/zou/postgresql.tar.bz2 )
-
 # create /var/run/postgresql
 . /usr/share/postgresql-common/init.d-functions
 create_socket_directory


### PR DESCRIPTION
According to the docker [documentation](https://docs.docker.com/engine/admin/volumes/#good-use-cases-for-volumes):

> Volumes are the preferred way to persist data in Docker containers and services.

Then there is no need to import `/var/log/postgresql/9.5` from archive ([doc](https://docs.docker.com/engine/admin/volumes/#tips-for-using-bind-mounts-or-volumes)):
> If you mount an empty volume into a directory in the container in which files or directories exist, these files or directories will be propagated (copied) into the volume.