### PR TITLE
Fix README tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ See [Gazu](https://gazu.cg-wire.com/) for details regarding the Python API towar
 
 ```bash
 $ docker build -t cgwire .
-$ docker run -ti --rm -p 80:80 --name cgwire cgwire
+$ docker run -ti --rm -p 80:80 --name cgwire cgwire/cgwire
 ```
 
 In order to enable data persistence, use a named volume for database and thumbnails:
 
 ```bash
 $ docker build -t cgwire .
-$ docker run -ti --rm -p 80:80 --name cgwire -v zou-storage:/var/lib/postgresql -v zou-storage:/opt/zou/zou/thumbnails cgwire
+$ docker run -ti --rm -p 80:80 --name cgwire -v zou-storage:/var/lib/postgresql -v zou-storage:/opt/zou/zou/thumbnails cgwire/cgwire
 ```
 
 Credentials:


### PR DESCRIPTION
**Problem**

The commands in the tutorial don't work.

**Solution**

Change the name of the public image used to build the container with the right one.