### PR TITLE
Let PostgreSQL handles logs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,8 +51,10 @@ RUN service postgresql start && \
 USER root
 
 # Wait for the startup or shutdown to complete
-COPY pg_ctl.conf /etc/postgresql/10/main/pg_ctl.conf
-RUN chmod 0644 /etc/postgresql/10/main/pg_ctl.conf && chown postgres:postgres /etc/postgresql/10/main/pg_ctl.conf
+COPY --chown=postgres:postgres pg_ctl.conf /etc/postgresql/10/main/pg_ctl.conf
+RUN chmod 0644 /etc/postgresql/10/main/pg_ctl.conf
+COPY --chown=postgres:postgres postgresql-log.conf /etc/postgresql/10/main/conf.d/postgresql-log.conf
+RUN chmod 0644 /etc/postgresql/10/main/conf.d/postgresql-log.conf
 
 
 COPY ./gunicorn /etc/zou/gunicorn.conf

--- a/postgresql-log.conf
+++ b/postgresql-log.conf
@@ -1,0 +1,5 @@
+# Keep 7 logs at the most
+log_directory = '/var/log/postgresql/'
+logging_collector = on
+log_filename = 'postgresql-%u.log'
+log_truncate_on_rotation = on

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -19,8 +19,8 @@ autostart=true
 autorestart=true
 # forcefully disconnect all clients
 stopsignal=SIGINT
-stdout_logfile=/var/log/postgresql/postgresql-10-main.log
-redirect_stderr=true
+stdout_logfile=NONE
+stderr_logfile=NONE
 priority=100
 
 [program:nginx]

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -28,8 +28,8 @@ command = nginx -g "daemon off;"
 autostart = true
 autorestart = true
 stopwaitsecs = 5
-stdout_logfile=/var/log/nginx/access.log
-stdout_logfile=/var/log/nginx/error.log
+stdout_logfile=NONE
+stderr_logfile=NONE
 
 [program:gunicorn]
 environment=PREVIEW_FOLDER=/opt/zou/previews,DB_USERNAME=root,DB_PASSWORD=''
@@ -37,14 +37,16 @@ command=/opt/zou/env/bin/gunicorn -c /etc/zou/gunicorn.conf -b 127.0.0.1:5000 --
 directory=/opt/zou
 autostart=true
 autorestart=true
-redirect_stderr=true
+stdout_logfile=NONE
+stderr_logfile=NONE
 
 [program:gunicorn-events]
 command=/opt/zou/env/bin/gunicorn -c /etc/zou/gunicorn-events.conf -b 127.0.0.1:5001 zou.event_stream:app
 directory=/opt/zou
 autostart=true
 autorestart=true
-redirect_stderr=true
+stdout_logfile=NONE
+stderr_logfile=NONE
 
 [group:zou-processes]
 programs=gunicorn,gunicorn-events


### PR DESCRIPTION
Fix this issue:

    $ http POST localhost:80/api/auth/login email=admin@example.com password=mysecretpassword
    {"error": true, "login": false, "message": "Database doesn't seem reachable."}

Since the builds with Ubuntu Focal are enabled (e25f5eb), [supervisord fails to start PostgreSQL](https://travis-ci.org/github/cgwire/cgwire/builds/737086081) because it wasn't allowed to write to the PostgreSQL log file.

And disable extraneous log files.

Fixes #16.